### PR TITLE
Auto-detect which delimiter is used in the CSV file

### DIFF
--- a/mplot/plot.py
+++ b/mplot/plot.py
@@ -76,12 +76,23 @@ def time_delta(df):
     return '{:.0f}d {:02.0f}:{:02.0f}.{:02.0f}'.format(d[0], h[0], m[0], int(s))
 
 
+# Auto-detect which delimiter is being used in the csv file.
+def detect_delimiter(options):
+    delims = [';', ',', '|']
+    with open(options.infile, 'r') as f:
+        first_line = f.readline()
+        for delim in delims:
+            if delim in first_line:
+                return delim
+        raise Exception("Could not detect delimiter used in CSV file!")
+
+
 def plot(options):
 
     sns.set(style="darkgrid")
     sns.set_palette(COLORS)
 
-    df = pd.read_csv(options.infile, delimiter=',')
+    df = pd.read_csv(options.infile, delimiter=detect_delimiter(options))
 
     # Apply a rolling average filter if requested via cmdline options.
     if options.avg_window is not None:

--- a/mplot/plot.py
+++ b/mplot/plot.py
@@ -42,6 +42,7 @@ import sys
 #
 # To avoid this, we instruct matplotlib to break up the plot into
 # chunks.  Thanks to https://stackoverflow.com/a/23361090
+import matplotlib
 matplotlib.rcParams['agg.path.chunksize'] = 100000
 
 COLORS = ["#6e3c82", "#3498db", "#95a5a6", "#e74c3c", "#34495e", "#2ecc71"]
@@ -80,7 +81,16 @@ def plot(options):
     sns.set(style="darkgrid")
     sns.set_palette(COLORS)
 
-    df = pd.read_csv(options.infile, delimiter=';')
+    df = pd.read_csv(options.infile, delimiter=',')
+
+    # Apply a rolling average filter if requested via cmdline options.
+    if options.avg_window is not None:
+        window_len = options.avg_window
+        avg_df = df.rolling(window=window_len).mean()
+        # Until the window fills up, the output will be a bunch of NaN values,
+        # which we remove here:
+        avg_df = avg_df[window_len-1:]
+        df = avg_df
 
     plt.locator_params(axis='y', nticks=20)
 
@@ -170,6 +180,12 @@ def main():
                         action='store',
                         default="7",
                         help='Number of least significant digits in the Y labels')
+    parser.add_argument('-a',
+                        '--rolling-average-window',
+                        dest='avg_window',
+                        type=int,
+                        action='store',
+                        help='Apply a rolling-average with a window of N data points')
     options = parser.parse_args()
 
     if options.infile is None:


### PR DESCRIPTION
This PR adds some crude logic to detect which delimiter is being used in the CSV file.

It looks at the first line of the file for occurrences of `;`, `,`, and `|`.